### PR TITLE
Add "Link local CSS-File"-Feature

### DIFF
--- a/BetterSyntax/BetterSyntax.plugin.js
+++ b/BetterSyntax/BetterSyntax.plugin.js
@@ -320,6 +320,7 @@ module.exports = (() => {
                           BdApi.clearCSS("BetterSyntaxButtons");
                           BdApi.clearCSS("BetterSyntaxEditorTheme");
                           BdApi.clearCSS("BetterSyntaxHljsLink");
+                          BdApi.clearCSS("BetterSyntaxHljsFile");
                           Patcher.unpatchAll();
                       }
 
@@ -397,6 +398,19 @@ module.exports = (() => {
                               BdApi.injectCSS("BetterSyntaxHljsLink", `@import url("${this.settings.categoryLink.link}");`);
                           } else {
                               BdApi.clearCSS("BetterSyntaxHljsLink");
+                          }
+
+                          if (this.settings.categoryFile.enableFile) {
+                              let css = "";
+                              if (this.settings.categoryFile.filePath) {
+                                  let fs = require("fs");
+                                  if (fs.existsSync(this.settings.categoryFile.filePath)) {
+                                      css = fs.readFileSync(this.settings.categoryFile.filePath, {encoding: "utf8"});
+                                  }
+                              }
+                              BdApi.injectCSS("BetterSyntaxHljsFile", css);
+                          } else {
+                              BdApi.clearCSS("BetterSyntaxHljsFile");
                           }
                       }
 

--- a/BetterSyntax/BetterSyntax.plugin.js
+++ b/BetterSyntax/BetterSyntax.plugin.js
@@ -210,6 +210,30 @@ module.exports = (() => {
                 ],
             },
             {
+                type: "category",
+                id: "categoryFile",
+                name: "Link CSS File",
+                collapsible: true,
+                shown: true,
+                settings: [
+                    {
+                        type: "switch",
+                        id: "enableFile",
+                        name: "Enable File Module",
+                        note: "Without this, nothing in this category will apply.",
+                        value: false,
+                    },
+                    {
+                        type: "textbox",
+                        placeholder: "C:/User/Desktop/hljs.css",
+                        id: "filePath",
+                        name: "File Path",
+                        note: "Path to a hljs stylesheet",
+                        value: ""
+                    }
+                ],
+            },
+            {
                 type: "textbox",
                 placeholder: "Source Code Pro",
                 id: "fontName",

--- a/BetterSyntax/BetterSyntax.plugin.js
+++ b/BetterSyntax/BetterSyntax.plugin.js
@@ -400,14 +400,14 @@ module.exports = (() => {
                               BdApi.clearCSS("BetterSyntaxHljsLink");
                           }
 
-                          if (this.settings.categoryFile.enableFile) {
+                          if (this.settings.categoryFile.enableFile && this.settings.categoryFile.filePath) {
+                              const fs = require("fs");
+
                               let css = "";
-                              if (this.settings.categoryFile.filePath) {
-                                  let fs = require("fs");
-                                  if (fs.existsSync(this.settings.categoryFile.filePath)) {
-                                      css = fs.readFileSync(this.settings.categoryFile.filePath, {encoding: "utf8"});
-                                  }
+                              if (fs.existsSync(this.settings.categoryFile.filePath)) {
+                                  css = fs.readFileSync(this.settings.categoryFile.filePath, {encoding: "utf8"});
                               }
+
                               BdApi.injectCSS("BetterSyntaxHljsFile", css);
                           } else {
                               BdApi.clearCSS("BetterSyntaxHljsFile");

--- a/BetterSyntax/BetterSyntax.plugin.js
+++ b/BetterSyntax/BetterSyntax.plugin.js
@@ -2,7 +2,7 @@
  * @name BetterSyntax
  * @author TheCommieAxolotl#0001
  * @description Lets you edit Syntax Highlighting with an easy interface and adds some useful buttons.
- * @version 2.0.2
+ * @version 2.1.0
  * @authorId 538487970408300544
  * @invite 5BSWtSM3XU
  * @source https://github.com/TheCommieAxolotl/BetterDiscord-Stuff/tree/main/BetterSyntax
@@ -36,7 +36,7 @@ module.exports = (() => {
                 },
             ],
             github_raw: "https://raw.githubusercontent.com/TheCommieAxolotl/BetterDiscord-Stuff/main/BetterSyntax/BetterSyntax.plugin.js",
-            version: "2.0.2",
+            version: "2.1.0",
             description: "Lets you edit Syntax Highlighting with an easy interface and adds some useful buttons.",
         },
 
@@ -261,9 +261,9 @@ module.exports = (() => {
 
         changelog: [
             {
-                title: "Improved",
-                type: "improved",
-                items: ["Some More Maintainable Styles", "Wont flood console with Logs"],
+                title: "New Feature",
+                type: "added",
+                items: ["Added feature to load CSS from local file"],
             },
         ],
     };


### PR DESCRIPTION
Adds the feature to select a HLJS-Stylesheet on your computer and load it into the Discord DOM. Thought would be a neat little feature if you want to select a custom hljs stylesheet that is located on your computer (using the link feature with a file-link like: file://C:/User/Desktop/hljs.css did not work for me)