### PR TITLE
Fix alignmentment of avatarWrapper

### DIFF
--- a/Ultra/Ultra.css
+++ b/Ultra/Ultra.css
@@ -94,8 +94,8 @@ svg.cursorDefault--wfhy5 {
 
 .avatarWrapperNormal-ahVUaC {
     position: absolute;
-    transform: translate(-50%);
-    left: 50%;
+    transform: translate(50%);
+    left: -5%;
 }
 
 .headerTop-3GPUSF {


### PR DESCRIPTION
Sometime over the past 24 hours something changed causing profile pictures to shift to the right.
This is the element causing the issue, I have aligned it best I could but you may want to tinker with it more yourself after reviewing.