### PR TITLE
update PreviewMessage webpack module filter

### DIFF
--- a/PreviewMessage/PreviewMessage.plugin.js
+++ b/PreviewMessage/PreviewMessage.plugin.js
@@ -102,7 +102,7 @@ module.exports = (() => {
                   const SelectedChannelStore = Webpack.getModule((m) => m.getLastSelectedChannelId);
                   const DraftStore = Webpack.getModule((m) => m.getDraft);
                   const MessageActions = Webpack.getModule((m) => m.sendBotMessage);
-                  const ChannelTextArea = Webpack.getModule((m) => m.type?.render?.toString?.().includes("CHANNEL_TEXT_AREA).AnalyticsLocationProvider"));
+                  const ChannelTextArea = Webpack.getModule((m) => m.type?.render?.toString?.().includes("CHANNEL_TEXT_AREA"));
 
                   return class PreviewMessage extends Plugin {
                       onStart() {


### PR DESCRIPTION
updates the PreviewMessage `ChannelTextArea` webpack module search string as recent Discord changes have caused the previous string to fail. This change fixes the module lookup - and based on my brief testing, at least, there do not appear to be any other modules with the text `CHANNEL_TEXT_AREA` included anywhere in `module.type.render.toString()` at this time.

Fixes #69 