### PR TITLE
Bump version in Timezones.plugin.js

### DIFF
--- a/Timezones/Timezones.plugin.js
+++ b/Timezones/Timezones.plugin.js
@@ -21,7 +21,7 @@ module.exports = (() => {
                 },
             ],
             github_raw: "https://raw.githubusercontent.com/TheCommieAxolotl/BetterDiscord-Stuff/main/Timezones/Timezones.plugin.js",
-            version: "1.0.3",
+            version: "1.0.4",
             description: "Allows you to display other Users' local times.",
         },
         defaultConfig: [


### PR DESCRIPTION
PluginRepo keeps saying there's an update and re-downloading the same `1.0.4` since it's still thinking `1.0.3` is installed due to the version not also being bumped here after the latest commit. Just a simple fix for that issue.