### PR TITLE
Fix timestamps not displaying

### DIFF
--- a/Timezones/Timezones.plugin.js
+++ b/Timezones/Timezones.plugin.js
@@ -171,7 +171,7 @@ module.exports = (() => {
 
                               ret.props.username.props.children.push(
                                   React.createElement(Tooltip, {
-                                      text: this.getTime(props.message.author.id, props.message.timestamp._d, {
+                                      text: this.getTime(props.message.author.id, props.message.timestamp, {
                                           weekday: "long",
                                           year: "numeric",
                                           month: "long",
@@ -183,7 +183,7 @@ module.exports = (() => {
                                           React.createElement(
                                               "span",
                                               { ...p, className: "timezone" },
-                                              this.getTime(props.message.author.id, props.message.timestamp._d, { hour: "numeric", minute: "numeric" })
+                                              this.getTime(props.message.author.id, props.message.timestamp, { hour: "numeric", minute: "numeric" })
                                           ),
                                   })
                               );


### PR DESCRIPTION
The plugin suddenly stopped working today on stable (266159). I don't know what the `props.message.timestamp` object looked like before, but it doesn't have the `._d` attribute now. Passing the whole timestamp appears to fix this issue.

This issue is probably identical to #85, as it gives the same stack trace.